### PR TITLE
Added some test cases

### DIFF
--- a/test-cases/2013-10-02_furloughed.json
+++ b/test-cases/2013-10-02_furloughed.json
@@ -1,0 +1,18 @@
+{
+    "Id": 531,
+    "Title": "Federal Government Operating Status in the Washington, DC, Area",
+    "Location": "Washington, DC area",
+    "StatusSummary": "Due to a lapse in appropriations, Federal government operations vary by agency.",
+    "StatusWebPage": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/",
+    "ShortStatusMessage": "Employees should refer to their home agency for guidance on reporting for duty.",
+    "LongStatusMessage": "Employees should refer to their home agency for guidance on reporting for duty.\r\nDue to a lapse in appropriations, Federal government operations vary by agency.\u0026nbsp; Employees should refer to their home agency for guidance on reporting for duty. ",
+    "ExtendedInformation": "Due to a lapse in appropriations, Federal government operations vary by agency.\u0026nbsp; Employees should refer to their home agency for guidance on reporting for duty. ",
+    "DateStatusPosted": "\/Date(1380634171327)\/",
+    "CurrentDate": "\/Date(1695480672169)\/",
+    "DateStatusComplete": "\/Date(1381978800000)\/",
+    "AppliesTo": "All Federal Government",
+    "Icon": "Alert",
+    "StatusType": "Custom Status Message",
+    "StatusTypeGuid": "30b9681e-252d-4a9a-9247-4ea209bd1f55",
+    "Url": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/status-archives/13/10/1/Due-to-a-lapse-in-appropriations-Federal-government-operations-vary-by-agency_531/"
+}

--- a/test-cases/2018-12-31_furloughed.json
+++ b/test-cases/2018-12-31_furloughed.json
@@ -1,0 +1,18 @@
+{
+    "Id": 848,
+    "Title": "Federal Government Operating Status in the Washington, DC, Area",
+    "Location": "Washington, DC Area",
+    "StatusSummary": "Due to a lapse in appropriations, Federal Government operations vary by agency.",
+    "StatusWebPage": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/",
+    "ShortStatusMessage": "Employees should refer to their home agency for guidance on reporting for duty.",
+    "LongStatusMessage": "Employees should refer to their home agency for guidance on reporting for duty.\r\nEmployees should refer to their home agency for guidance on reporting for duty. ",
+    "ExtendedInformation": "Employees should refer to their home agency for guidance on reporting for duty. ",
+    "DateStatusPosted": "\/Date(1545800400000)\/",
+    "CurrentDate": "\/Date(1695440906227)\/",
+    "DateStatusComplete": "\/Date(1547430000000)\/",
+    "AppliesTo": "All Federal Government, until further notice",
+    "Icon": "Alert",
+    "StatusType": "Custom Status Message",
+    "StatusTypeGuid": "30b9681e-252d-4a9a-9247-4ea209bd1f55",
+    "Url": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/status-archives/18/12/26/Due-to-a-lapse-in-appropriations-Federal-Government-operations-vary-by-agency_848/"
+}

--- a/test-cases/2019-12-15_furloughed.json
+++ b/test-cases/2019-12-15_furloughed.json
@@ -1,0 +1,18 @@
+{
+    "Id": 0,
+    "Title": "Federal Government Operating Status in the Washington, DC, Area",
+    "Location": "Washington, DC area",
+    "StatusSummary": "Open",
+    "StatusWebPage": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/",
+    "ShortStatusMessage": "Federal agencies in the Washington, DC area are Open.",
+    "LongStatusMessage": "Federal agencies in the Washington, DC area are Open.\r\n Employees are expected to begin the workday on time.  Normal operating procedures are in effect.",
+    "ExtendedInformation": " Employees are expected to begin the workday on time.  Normal operating procedures are in effect.",
+    "DateStatusPosted": "\/Date(1576386000000)\/",
+    "CurrentDate": "\/Date(1695475792950)\/",
+    "DateStatusComplete": null,
+    "AppliesTo": "December 15, 2019",
+    "Icon": "Open",
+    "StatusType": "Open",
+    "StatusTypeGuid": "e3e3d34b-05ae-451a-b13a-93a1ac92dfe4",
+    "Url": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/"
+}

--- a/test-cases/2023-09-23_normal.json
+++ b/test-cases/2023-09-23_normal.json
@@ -1,0 +1,18 @@
+{
+    "Id": 0,
+    "Title": "Federal Government Operating Status in the Washington, DC, Area",
+    "Location": "Washington, DC area",
+    "StatusSummary": "Open",
+    "StatusWebPage": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/",
+    "ShortStatusMessage": "Federal agencies in the Washington, DC area are Open.",
+    "LongStatusMessage": "Federal agencies in the Washington, DC area are Open.\r\n Employees are expected to begin the workday on time.  Normal operating procedures are in effect.",
+    "ExtendedInformation": " Employees are expected to begin the workday on time.  Normal operating procedures are in effect.",
+    "DateStatusPosted": "\/Date(1695441870183)\/",
+    "CurrentDate": "\/Date(1695442023664)\/",
+    "DateStatusComplete": null,
+    "AppliesTo": "September 23, 2023",
+    "Icon": "Open",
+    "StatusType": "Open",
+    "StatusTypeGuid": "e3e3d34b-05ae-451a-b13a-93a1ac92dfe4",
+    "Url": "https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/current-status/"
+}


### PR DESCRIPTION
Some observations:
- [OPM's status types API](https://www.opm.gov/json/statustypes.json) do not mention furlough explicitly, and often will leave the status as "open" but put details in the status message fields.
- Furloughs are signaled using language such as "lapse in appropriations", "furlough", and "vary by agency"
- Deciding on furlough status could be as simple as searching the raw response for the above keywords.